### PR TITLE
Add optional argument to `:GuessIndent` to respect user config

### DIFF
--- a/doc/guess_indent.txt
+++ b/doc/guess_indent.txt
@@ -54,7 +54,8 @@ instead.
 `filetype_exclude`	A list of file types. If you open a buffer and its
 			'filetype' is contained in this list, then 
 			guess-indent won't run automatically. Note this only
-			changes the behavior if `auto_cmd` is set to true.
+			changes the behavior if `auto_cmd` is set to true or if
+			`:GuessIndent`is run with argument `auto_cmd` .
 
 `buftype_exclude`	Same as `filetype_exclude` but for 'buftype' instead.
 
@@ -67,6 +68,9 @@ COMMANDS                                                *GuessIndent-commands*
 
 Guess-indent respects the 'verbose' option. This means that you can run it
 using `:verbose GuessIndent` to get verbose output. 
+
+If you want to run guess-indent from your own auto command you can specify the
+context as an argument using `:GuessIndent auto_cmd` .
 
 ==============================================================================
 LICENSE                                                  *GuessIndent-license*

--- a/lua/guess-indent/init.lua
+++ b/lua/guess-indent/init.lua
@@ -5,7 +5,7 @@ local M = {}
 
 local function setup_commands()
   vim.cmd([[
-    command! GuessIndent :lua require("guess-indent").set_from_buffer()
+    command! -nargs=? GuessIndent :lua require("guess-indent").set_from_buffer("<args>")
   ]])
 end
 
@@ -13,9 +13,9 @@ local function setup_autocommands()
   vim.cmd([[
     augroup GuessIndent
       autocmd!
-      autocmd BufReadPost * silent lua require("guess-indent").set_from_buffer(true)
+      autocmd BufReadPost * silent lua require("guess-indent").set_from_buffer("auto_cmd")
       " Run once when saving for new files
-      autocmd BufNewFile * autocmd BufWritePost <buffer=abuf> ++once silent lua require("guess-indent").set_from_buffer(true)
+      autocmd BufNewFile * autocmd BufWritePost <buffer=abuf> ++once silent lua require("guess-indent").set_from_buffer("auto_cmd")
     augroup END
   ]])
 end
@@ -263,10 +263,10 @@ function M.guess_from_buffer()
 end
 
 -- Set the indentation based on the contents of the current buffer.
--- The argument `auto_cmd` should only be set to true if this function gets
+-- The argument `context` should only be set to `auto_cmd` if this function gets
 -- called by an auto command.
-function M.set_from_buffer(auto_cmd)
-  if auto_cmd then
+function M.set_from_buffer(context)
+  if context == "auto_cmd" then
     -- Filter
     local filetype = vim.bo.filetype
     local buftype = vim.bo.buftype


### PR DESCRIPTION
Fixes #7 by adding optional argument to `:GuessIndent` that can specify the command is being run from an autocmd.

Running `:GuessIndent auto_cmd` respects the user config for file types and buffer types to exclude, even if `auto_cmd` is set to false.