### PR TITLE
Improve setting option values, and add user events

### DIFF
--- a/lua/guess-indent/config.lua
+++ b/lua/guess-indent/config.lua
@@ -2,6 +2,8 @@ local M = {}
 
 local default_config = {
   auto_cmd = true,
+  set_tabstop = true,
+  set_softtabstop = true,
   filetype_exclude = {
     "netrw",
     "tutor",

--- a/lua/guess-indent/init.lua
+++ b/lua/guess-indent/init.lua
@@ -66,15 +66,26 @@ local function set_indentation(indentation)
 
   if indentation == "tabs" then
     set_buffer_opt(0, "expandtab", false)
+    set_buffer_opt(0, "shiftwidth", 0)
+    if config.set_softtabstop then
+      set_buffer_opt(0, "softtabstop", 0)
+    end
     print("Did set indentation to tabs.")
+    vim.api.nvim_exec_autocmds("User", { pattern = "GuessIndentTabs" })
   elseif type(indentation) == "number" and indentation > 0 then
     set_buffer_opt(0, "expandtab", true)
-    set_buffer_opt(0, "tabstop", indentation)
-    set_buffer_opt(0, "softtabstop", indentation)
     set_buffer_opt(0, "shiftwidth", indentation)
+    if config.set_softtabstop then
+      set_buffer_opt(0, "softtabstop", indentation)
+    end
+    if config.set_tabstop then
+      set_buffer_opt(0, "tabstop", indentation)
+    end
     print("Did set indentation to", indentation, "spaces.")
+    vim.api.nvim_exec_autocmds("User", { pattern = "GuessIndentSpaces" })
   else
     print("Failed to detect indentation style.")
+    vim.api.nvim_exec_autocmds("User", { pattern = "GuessIndentNone" })
   end
 end
 


### PR DESCRIPTION
Add user events to allow the user to customize the indentation after the
detection, to fix some options that might be inherited from the initial
configuration. Allows to customize via the configuration which options
are set.

When tabs are detected, set shiftwidth=0 to ensure that the shifting
value is the same as the tabstop. Same with softtabstop=0 to disable it.
When spaces are detected, make optional setting of the tabstop and
softtabstop option.

Use case: In my init.vim I set default indent options for empty files:

```vim
set sw=2 sts=0 ts=8 et
```

When guess-indent detects a file with tabs, it needs to be able to override these values.

Also, I prefer to always keep a tabstop of 8 characters, so I prefer not to have the value changed. And I also prefer to keep the softtabstop option disabled, but if it is enabled when spaces are detected, it needs to be disabled wen tabs are detected.