### PR TITLE
editorconfig support

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,21 +2,21 @@ name: Style checking
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
   workflow_dispatch:
-
 
 jobs:
   stylua:
     name: StyLua
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Lint with stylua
-        uses: JohnnyMorganz/stylua-action@1.0.0
+        uses: JohnnyMorganz/stylua-action@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          version: latest
           args: --color always --check lua/

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ The plugin provides the following configuration options:
 -- This is the default configuration
 require('guess-indent').setup {
   auto_cmd = true,  -- Set to false to disable automatic execution
+  override_editorconfig = false, -- Set to true to override settings set by .editorconfig
   filetype_exclude = {  -- A list of filetypes for which the auto command gets disabled
     "netrw",
     "tutor",

--- a/doc/guess_indent.txt
+++ b/doc/guess_indent.txt
@@ -51,6 +51,10 @@ instead.
 			created that guesses the indentation style for each
 			buffer that gets opened.
 
+`override_editorconfig`	If this option is set to true, guessed indentation
+			will take precedence over settings set by
+			.editorconfig
+
 `filetype_exclude`	A list of file types. If you open a buffer and its
 			'filetype' is contained in this list, then 
 			guess-indent won't run automatically. Note this only

--- a/doc/guess_indent.txt
+++ b/doc/guess_indent.txt
@@ -53,7 +53,9 @@ instead.
 
 `override_editorconfig`	If this option is set to true, guessed indentation
 			will take precedence over settings set by
-			.editorconfig
+			.editorconfig. Note this only changes the behavior if
+			`auto_cmd` is set to true or if `:GuessIndent` is run
+			with argument `autocmd`.
 
 `filetype_exclude`	A list of file types. If you open a buffer and its
 			'filetype' is contained in this list, then 

--- a/lua/guess-indent/config.lua
+++ b/lua/guess-indent/config.lua
@@ -2,6 +2,7 @@ local M = {}
 
 local default_config = {
   auto_cmd = true,
+  override_editorconfig = false,
   filetype_exclude = {
     "netrw",
     "tutor",

--- a/lua/guess-indent/init.lua
+++ b/lua/guess-indent/init.lua
@@ -266,14 +266,16 @@ end
 -- The argument `context` should only be set to `auto_cmd` if this function gets
 -- called by an auto command.
 function M.set_from_buffer(context)
-  if not config.override_editorconfig then
-    local editorconfig = vim.b.editorconfig
-    if editorconfig and (editorconfig.indent_style or editorconfig.indent_size or editorconfig.tab_width) then
-      utils.v_print(1, "Excluded because of editorconfig settings.")
-      return
-    end
-  end
   if context == "auto_cmd" then
+    -- editorconfig interoperability
+    if not config.override_editorconfig then
+      local editorconfig = vim.b.editorconfig
+      if editorconfig and (editorconfig.indent_style or editorconfig.indent_size or editorconfig.tab_width) then
+        utils.v_print(1, "Excluded because of editorconfig settings.")
+        return
+      end
+    end
+
     -- Filter
     local filetype = vim.bo.filetype
     local buftype = vim.bo.buftype

--- a/lua/guess-indent/init.lua
+++ b/lua/guess-indent/init.lua
@@ -266,6 +266,11 @@ end
 -- The argument `context` should only be set to `auto_cmd` if this function gets
 -- called by an auto command.
 function M.set_from_buffer(context)
+  local editorconfig = vim.b.editorconfig
+  if editorconfig and (editorconfig.indent_style or editorconfig.indent_size or editorconfig.tab_width) then
+    utils.v_print(1, "Excluded because of editorconfig settings.")
+    return
+  end
   if context == "auto_cmd" then
     -- Filter
     local filetype = vim.bo.filetype

--- a/lua/guess-indent/init.lua
+++ b/lua/guess-indent/init.lua
@@ -266,10 +266,12 @@ end
 -- The argument `context` should only be set to `auto_cmd` if this function gets
 -- called by an auto command.
 function M.set_from_buffer(context)
-  local editorconfig = vim.b.editorconfig
-  if editorconfig and (editorconfig.indent_style or editorconfig.indent_size or editorconfig.tab_width) then
-    utils.v_print(1, "Excluded because of editorconfig settings.")
-    return
+  if not config.override_editorconfig then
+    local editorconfig = vim.b.editorconfig
+    if editorconfig and (editorconfig.indent_style or editorconfig.indent_size or editorconfig.tab_width) then
+      utils.v_print(1, "Excluded because of editorconfig settings.")
+      return
+    end
   end
   if context == "auto_cmd" then
     -- Filter


### PR DESCRIPTION
Neovim v0.9 is coming with `editorconfig` support. In cases where a `.editorconfig` file is detected, this plugin shouldn't override the settings that it sets. This does a basic check to see if the `.editorconfig` sets any indentation settings and then chooses to ignore overwriting these.

This also adds an option to the configuration `override_editorconfig` to control this, it defaults to `false` which does not override editorconfig settings.