### PR TITLE
Trigger OptionSet autocmd on option updates

### DIFF
--- a/lua/guess-indent/init.lua
+++ b/lua/guess-indent/init.lua
@@ -61,7 +61,7 @@ local function set_indentation(indentation)
     local current = vim.api.nvim_buf_get_option(buffer, name)
     if value ~= current then
       vim.api.nvim_buf_set_option(buffer, name, value)
-      vim.cmd("doautocmd OptionSet " .. name)
+      vim.api.nvim_exec_autocmds("OptionSet", { pattern = name })
     end
   end
 

--- a/lua/guess-indent/init.lua
+++ b/lua/guess-indent/init.lua
@@ -61,6 +61,7 @@ local function set_indentation(indentation)
     local current = vim.api.nvim_buf_get_option(buffer, name)
     if value ~= current then
       vim.api.nvim_buf_set_option(buffer, name, value)
+      vim.cmd("doautocmd OptionSet " .. name)
     end
   end
 

--- a/lua/guess-indent/init.lua
+++ b/lua/guess-indent/init.lua
@@ -61,8 +61,9 @@ local function set_indentation(indentation)
     local current = vim.api.nvim_buf_get_option(buffer, name)
     if value ~= current then
       vim.api.nvim_buf_set_option(buffer, name, value)
-      vim.api.nvim_exec_autocmds("OptionSet", { pattern = name })
     end
+    -- always doautocmd to ensure each newly loaded buffer gets an autocmd trigger
+    vim.api.nvim_exec_autocmds("OptionSet", { pattern = name })
   end
 
   if indentation == "tabs" then


### PR DESCRIPTION
Hello,

This proposal adds triggering of doautocmd OptionSet calls on each option being set. This would otherwise happen if we were setting it in the Vim cmd, but doesn't through the `nvim_buf_set_option` API call.

In terms of usability, it allows for autocmd triggers based on these buffer option updates.

Best,
Thaer