### PR TITLE
Add options to customize vim indentation options

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,15 @@ require('guess-indent').setup {
     "terminal",
     "prompt",
   },
+  on_tab_options = { -- A table of vim options when tabs are detected 
+    ["expandtab"] = false,
+  },
+  on_space_options = { -- A table of vim options when spaces are detected 
+    ["expandtab"] = true,
+    ["tabstop"] = "detected", -- If the option value is 'detected', The value is set to the automatically detected indent size.
+    ["softtabstop"] = "detected",
+    ["shiftwidth"] = "detected",
+  },
 }
 ```
 

--- a/doc/guess_indent.txt
+++ b/doc/guess_indent.txt
@@ -65,6 +65,12 @@ instead.
 
 `buftype_exclude`	Same as `filetype_exclude` but for 'buftype' instead.
 
+`on_tab_options`	A table of vim options when tabs are detected.
+
+`on_space_options`	A table of vim options when spaces are detected.
+			If the option value is `'detected'`, The value is set
+			to the automatically detected indent size.
+
 ==============================================================================
 COMMANDS                                                *GuessIndent-commands*
 

--- a/lua/guess-indent/config.lua
+++ b/lua/guess-indent/config.lua
@@ -5,6 +5,8 @@ local M = {}
 ---@field override_editorconfig boolean? Whether or not to override indentation set by Editorconfig
 ---@field filetype_exclude string[]? Filetypes to ignore indentation detection in
 ---@field buftype_exclude string[]? Buffer types to ignore indentation detection in
+---@field on_tab_options table<string, any>? A table of vim options when tabs are detected
+---@field on_space_options table<string, any>? A table of vim options when spaces are detected
 
 ---@class GuessIndentConfigModule: GuessIndentConfig
 ---@field set_config fun(GuessIndentConfig)
@@ -22,6 +24,15 @@ local default_config = {
     "nofile",
     "terminal",
     "prompt",
+  },
+  on_tab_options = {
+    ["expandtab"] = false,
+  },
+  on_space_options = {
+    ["expandtab"] = true,
+    ["tabstop"] = "detected",
+    ["softtabstop"] = "detected",
+    ["shiftwidth"] = "detected",
   },
 }
 

--- a/lua/guess-indent/init.lua
+++ b/lua/guess-indent/init.lua
@@ -110,13 +110,17 @@ local function set_indentation(indentation, bufnr, silent)
 
   local notification = "Failed to detect indentation style."
   if indentation == "tabs" then
-    set_buffer_opt(bufnr, "expandtab", false)
+    for opt, value in pairs(config.on_tab_options) do
+      set_buffer_opt(bufnr, opt, value)
+    end
     notification = "Did set indentation to tabs."
   elseif type(indentation) == "number" and indentation > 0 then
-    set_buffer_opt(bufnr, "expandtab", true)
-    set_buffer_opt(bufnr, "tabstop", indentation)
-    set_buffer_opt(bufnr, "softtabstop", indentation)
-    set_buffer_opt(bufnr, "shiftwidth", indentation)
+    for opt, value in pairs(config.on_space_options) do
+      if value == "detected" then
+        value = indentation
+      end
+      set_buffer_opt(bufnr, opt, value)
+    end
     notification = ("Did set indentation to %s space(s)."):format(indentation)
   end
   if not silent then


### PR DESCRIPTION
Hello.

I have added an option to set any vim option when indentation is detected.
Right now the options to set are hard coded, but I do not think this is appropriate from a customizability standpoint.
Because vim's indentation-related settings are so complex, I thought it best to allow users to set them freely.

There are many vim users who have the tab width set to 8 or have not changed it.
I do not think it is good from the user's point of view to change the 'tabstop' when spaces are detected.

For example, projects such as gcc and vim use an indentation style that mixes tabs and spaces, but only assumes that the tab width is 8.
The old-fashioned GNU style seems to use this indent style.
Therefore, making the tab width the same as the indent width will mess up the layout.
You can see this by opening the following code in vim. (Please disable modeline in vim project)
https://github.com/gcc-mirror/gcc/blob/8f8db5553935edcb4731db32279418ca37e1f094/libgomp/config/posix/sem.c#L73-L76
https://github.com/vim/vim/blob/1bf1bf569b96d2f9b28e0cce0968ffbf2fb80aac/src/alloc.c#L97-L102

Another advantage of separating 'tabstop' from 'shiftwidth' is that if a tab is mistakenly entered, it is easier to tell that it is a tab without using :set list. The same size makes it impossible to distinguish between tabs and spaces.

For example, vim-sleuth does not change it.
The vim help below explains why.
```
:h 'tabstop'
:h usr_25.txt
:h usr_30.txt
```

I am going to define the default values as follows and change the following options.

default: 2 spaces, 8-width tab
```
opt.tabstop = 8          -- default
opt.softtabstop = -1  -- same as 'shiftwidth'
opt.shiftwidth = 2      -- indent is 2
opt.expandtab = true -- tab is not used
```

```
      on_tab_options = {
        ["expandtab"] = false,
        ["softtabstop"] = 0, -- make disabled
        ["shiftwidth"] = 0,   -- same as 'tabstop', Currently this is not set, so 'shiftwidth' is 2. I want to change this option when detecting tab.
      },
      on_space_options = {
        ["expandtab"] = true, -- same as default
        ["shiftwidth"] = "detected", -- only this option will be changed
        ["softtabstop"] = -1, -- same as default
      },
```

This is advantageous from a performance standpoint because it reduces the number of options to be set as much as possible.
Currently the same value is set for 'tabstop', 'softtabstop', and 'shiftwidth' when spaces are detected, but If 'softtabstop' is set to -1, there is no need to set it. or if 'tabstop' and 'softabstop' are equal, 'softtabstop' is almost no point, so it can be set to 0 or 1 instead.

BTW, The editorconfig that comes with neovim has almost the same configuration values.
(The fact that 'tabstop' is also changed is a result of following the editorconfig specification.)
https://github.com/neovim/neovim/blob/master/runtime/lua/editorconfig.lua#L50-L71


Also, the specific options to be set will be written in the README, which will make it easier to understand.

Default values are to be taken over from the current settings for compatibility reason.

This PR also fixes
PR:  #9
Issue: #12 

also related
PR: #14